### PR TITLE
Change default project ID for syncReceiver jobs

### DIFF
--- a/R/syncServer.R
+++ b/R/syncServer.R
@@ -39,7 +39,7 @@
 #'
 #' @author John Brzustowski \email{jbrzusto@@REMOVE_THIS_PART_fastmail.fm}
 
-syncServer = function(tracing = FALSE, fileEvent="CLOSE_WRITE", defaultMotusUserID = 347, defaultMotusProjectID = 1) {
+syncServer = function(tracing = FALSE, fileEvent="CLOSE_WRITE", defaultMotusUserID = 347, defaultMotusProjectID = 0) {
     if(tracing)
         options(error=recover)
 


### PR DESCRIPTION
Change default project ID for syncReceiver jobs when no deployments are known from project 1 to project 0.