### PR TITLE
Fix duplicate serial numbers in syncServer

### DIFF
--- a/R/syncServer.R
+++ b/R/syncServer.R
@@ -76,6 +76,15 @@ syncServer = function(tracing = FALSE, fileEvent="CLOSE_WRITE", defaultMotusUser
             if (tracing)
                 browser()
 
+            ## fix serial number if it's a duplicate
+            rules = MetaDB("select * from serno_collision_rules where serno = '%s' order by id", serno, .QUOTE = FALSE)
+            for (i in seq_len(nrow(rules))) {
+                if (eval(parse(text = rules$cond[i]))) {
+                    serno = paste0(serno, rules$suffix[i])
+                    break
+                }
+            }
+
             ## get sensible values for motus ProjectID and UserID
             if (is.na(motusProjectID)) {
                 ## lookup the latest unterminated deployment for this receiver, and use that


### PR DESCRIPTION
This is intended to start fixing https://github.com/MotusDev/Motus-TO-DO/issues/502

Since I can't test this except on the live server, I need (at least) a second set of eyes to make sure I haven't made a basic mistake somewhere. I'm assuming Joey is the best choice to review R code? The code is adapted from https://github.com/MotusWTS/motusServer/blob/master/R/parseFilenames.R
